### PR TITLE
In the intel preempt rt kernel repo, the name of the xhci driver is '…

### DIFF
--- a/rtirq.sh
+++ b/rtirq.sh
@@ -272,6 +272,7 @@ function rtirq_exec ()
 			rtirq_exec_name ${ACTION} "${NAME}" "uhci_hcd" ${PRI0}
 			rtirq_exec_name ${ACTION} "${NAME}" "ehci_hcd" ${PRI0}
 			rtirq_exec_name ${ACTION} "${NAME}" "xhci_hcd" ${PRI0}
+			rtirq_exec_name ${ACTION} "${NAME}" "xhci-hcd" ${PRI0}
 			;;
 		*)
 			rtirq_exec_name ${ACTION} "${NAME}" "${NAME}" ${PRI0}


### PR DESCRIPTION
…xhci-hcd' not 'xhci_hcd'

we are using this kernel git repo
https://github.com/intel/linux-intel-lts/tree/4.14/yocto/base-rt